### PR TITLE
Frontend: like functionality

### DIFF
--- a/frontend/src/api/like_api.js
+++ b/frontend/src/api/like_api.js
@@ -1,0 +1,74 @@
+import axios from "axios";
+
+export const post_like = async (
+  likedAuthorId,
+  likeAuthor,
+  postId,
+  context,
+  success
+) => {
+  console.log("Attempting to post likes for", { postId });
+  const data = {
+    type: "Like",
+    context: context,
+    author: likeAuthor,
+    object: `http://localhost:8000/authors/${likedAuthorId
+      .split("/")
+      .pop()}/posts/${postId.split("/").pop()}`,
+  };
+  const res = await axios.post(
+    `http://localhost:8000/authors/${likedAuthorId}/inbox/`,
+    data,
+    {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  console.log(res);
+  if (res.status === 202) {
+    console.log("Success!");
+    success(res.data);
+  } else {
+    console.log("Error Occured");
+  }
+};
+
+export const comment_like = async (
+  likedAuthorId,
+  likeAuthor,
+  postId,
+  commentId,
+  context,
+  success
+) => {
+  console.log("Attempting to post likes for", { commentId });
+  const data = {
+    type: "Like",
+    context: context,
+    author: likeAuthor,
+    object: `http://localhost:8000/authors/${likedAuthorId
+      .split("/")
+      .pop()}/posts/${postId.split("/").pop()}/comments/${commentId
+      .split("/")
+      .pop()}`,
+  };
+  const res = await axios.post(
+    `http://localhost:8000/authors/${likedAuthorId}/inbox/`,
+    data,
+    {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  console.log(res);
+  if (res.status === 202) {
+    console.log("Success!");
+    success(res.data);
+  } else {
+    console.log("Error Occured");
+  }
+};

--- a/frontend/src/api/like_api.js
+++ b/frontend/src/api/like_api.js
@@ -12,9 +12,47 @@ export const post_like = async (
     type: "Like",
     context: context,
     author: likeAuthor,
-    object: `http://localhost:8000/authors/${likedAuthorId
+    object: `http://localhost/authors/${likedAuthorId /* URL Needs to be updated once hosted on heroku */
       .split("/")
       .pop()}/posts/${postId.split("/").pop()}`,
+  };
+  const res = await axios.post(
+    `http://localhost:8000/authors/${likedAuthorId}/inbox/`,
+    data,
+    {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  console.log(res);
+  if (res.status === 202) {
+    console.log("Success!");
+    success();
+  } else {
+    console.log("Error Occured");
+  }
+};
+
+export const comment_like = async (
+  likedAuthorId,
+  likeAuthor,
+  postId,
+  commentId,
+  context,
+  success
+) => {
+  console.log("Attempting to post likes for", { commentId });
+  const data = {
+    type: "Like",
+    context: context,
+    author: likeAuthor,
+    object: `http://localhost/authors/${likedAuthorId /* URL Needs to be updated once hosted on heroku */
+      .split("/")
+      .pop()}/posts/${postId.split("/").pop()}/comments/${commentId
+      .split("/")
+      .pop()}`,
   };
   const res = await axios.post(
     `http://localhost:8000/authors/${likedAuthorId}/inbox/`,
@@ -35,28 +73,10 @@ export const post_like = async (
   }
 };
 
-export const comment_like = async (
-  likedAuthorId,
-  likeAuthor,
-  postId,
-  commentId,
-  context,
-  success
-) => {
-  console.log("Attempting to post likes for", { commentId });
-  const data = {
-    type: "Like",
-    context: context,
-    author: likeAuthor,
-    object: `http://localhost:8000/authors/${likedAuthorId
-      .split("/")
-      .pop()}/posts/${postId.split("/").pop()}/comments/${commentId
-      .split("/")
-      .pop()}`,
-  };
-  const res = await axios.post(
-    `http://localhost:8000/authors/${likedAuthorId}/inbox/`,
-    data,
+export const get_liked = async (authorId, success) => {
+  console.log("Attempting to get liked for", { authorId });
+  const res = await axios.get(
+    `http://localhost:8000/authors/${authorId}/liked`,
     {
       headers: {
         Accept: "application/json",
@@ -65,9 +85,9 @@ export const comment_like = async (
     }
   );
   console.log(res);
-  if (res.status === 202) {
+  if (res.status === 200) {
     console.log("Success!");
-    success(res.data);
+    success(res.data.items);
   } else {
     console.log("Error Occured");
   }

--- a/frontend/src/components/ListItems/post-list.js
+++ b/frontend/src/components/ListItems/post-list.js
@@ -1,17 +1,44 @@
-import React from 'react'
-import PlainPost from '../../components/Posts/post-text'
-import './post-list.css';
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import PlainPost from "../../components/Posts/post-text";
+import "./post-list.css";
+import { get_liked } from "../../api/like_api";
 
-function PostList({user_list}) { //gets a json object, and returns a list item for it
-    
-    return (
-        <div className='posts'>
-            <ul className='postsList'>
-                {console.log(user_list)}
-                {user_list.items.map((list_item) => <li className='post' key={list_item.id}> <PlainPost post={list_item}/> </li>)};
-            </ul>
-        </div>
-        );
-}   
+function PostList({ user_list }) {
+  const user = useSelector((state) => state.user);
+
+  //gets a json object, and returns a list item for it
+
+  const [liked, setLiked] = useState(null);
+
+  useEffect(() => {
+    get_liked(user.id, setLiked);
+  }, []);
+
+  function checkLiked(item) {
+    for (var i = 0; i < liked.length; i++) {
+      if (liked[i].object === item.id) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return (
+    liked && (
+      <div className="posts">
+        <ul className="postsList">
+          {console.log(user_list)}
+          {user_list.items.map((list_item) => (
+            <li className="post" key={list_item.id}>
+              <PlainPost post={list_item} liked={checkLiked(list_item)} />
+            </li>
+          ))}
+          ;
+        </ul>
+      </div>
+    )
+  );
+}
 
 export default PostList;

--- a/frontend/src/components/Posts/post-text.js
+++ b/frontend/src/components/Posts/post-text.js
@@ -1,11 +1,12 @@
 import "./posts.css";
 import { useState } from "react";
 import { useSelector } from "react-redux";
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown from "react-markdown";
 import { post_comment } from "../../api/comment_api";
+import { post_like } from "../../api/like_api";
 
 export default function PlainPost(data) {
-  console.log(typeof(data["post"]["content"]));
+  console.log(typeof data["post"]["content"]);
   const user = useSelector((state) => state.user);
   //Check if markdown
   let markdown = data["post"]["contentType"] === "text/markdown" ? true : false;
@@ -22,6 +23,14 @@ export default function PlainPost(data) {
   )
     .split("/")
     .pop()}`; // allows linking to the author who wrote the post
+
+  const like_success = (data) => {
+    console.log(data);
+  };
+
+  const like = () => {
+    post_like(data.post.author.id, user, data.post.id, "context", like_success);
+  };
 
   const [commentFieldVisibilty, setCommentFieldVisibilty] = useState(false);
   const [comment, setComment] = useState("");
@@ -55,15 +64,20 @@ export default function PlainPost(data) {
           {/* Will need to handle other post types here, plain for now */}
           <div className="content-container">
             <h5>{data["post"]["title"]}</h5>
-            {markdown && <ReactMarkdown className="content line" children={data["post"]["content"]}>
-{/* Mardown doesn't like leading whitespace */}
-                        </ReactMarkdown>}
-                        {(!markdown) && <div className="content line">
-                            {data["post"]["content"]}
-                        </div>}
+            {markdown && (
+              <ReactMarkdown
+                className="content line"
+                children={data["post"]["content"]}
+              >
+                {/* Mardown doesn't like leading whitespace */}
+              </ReactMarkdown>
+            )}
+            {!markdown && (
+              <div className="content line">{data["post"]["content"]}</div>
+            )}
           </div>
           <div className="interaction-options">
-            <button>like</button>
+            <button onClick={like}>like</button>
 
             <button
               onClick={() =>

--- a/frontend/src/components/Posts/post-text.js
+++ b/frontend/src/components/Posts/post-text.js
@@ -1,5 +1,5 @@
 import "./posts.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import ReactMarkdown from "react-markdown";
 import { post_comment } from "../../api/comment_api";
@@ -24,12 +24,8 @@ export default function PlainPost(data) {
     .split("/")
     .pop()}`; // allows linking to the author who wrote the post
 
-  const like_success = (data) => {
-    console.log(data);
-  };
-
-  const like = () => {
-    post_like(data.post.author.id, user, data.post.id, "context", like_success);
+  const like_success = () => {
+    /* Show Success Snackbar? */
   };
 
   const [commentFieldVisibilty, setCommentFieldVisibilty] = useState(false);
@@ -77,7 +73,20 @@ export default function PlainPost(data) {
             )}
           </div>
           <div className="interaction-options">
-            <button onClick={like}>like</button>
+            <button
+              disabled={data.liked}
+              onClick={() =>
+                post_like(
+                  data.post.author.id,
+                  user,
+                  data.post.id,
+                  "context",
+                  like_success
+                )
+              }
+            >
+              {data.liked ? "liked" : "like"}
+            </button>
 
             <button
               onClick={() =>

--- a/socialdistribution/service/admin.py
+++ b/socialdistribution/service/admin.py
@@ -7,7 +7,7 @@ admin.site.register(author.Author)
 #admin.site.register(follow.Followers)
 #admin.site.register(post.Post) #we don't need this here, but leaving as comment just in case
 #admin.site.register(post.Category)
-#admin.site.register(like.Likes)
+admin.site.register(like.Like)
 admin.site.register(comment.Comment)
 # admin.site.register(follow.Followers)
 #admin.site.register(inbox.Inbox)

--- a/socialdistribution/service/views/inbox.py
+++ b/socialdistribution/service/views/inbox.py
@@ -202,6 +202,8 @@ class InboxView(View):
         try:
             like = Like.objects.get(_id=id)
         except ObjectDoesNotExist:
+            print(body)
+            print(foreign_author)
             like = Like()
             like._id=id
             like.context=body["context"]


### PR DESCRIPTION
check whether the post(only currently as comment and like views are not implemented yet) have been liked by current user and make like button unclickable. I know 409 conflict raises in inbox api when there is a duplicated request but for better looks.
hostname of the object field needs to be update under like_api.js after hosting